### PR TITLE
update httpd 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,9 @@ RUN mkdir -p /etc/httpd/conf.d/vhosts
 ADD php-fpm.conf /etc/httpd/conf.d/
 ADD mounted-vhosts.conf /etc/httpd/conf.d/
 
+# Update and install latest packages and prerequisites
+RUN yum update -y \
+    && yum clean all && yum history new
+    
 EXPOSE 80
 EXPOSE 443


### PR DESCRIPTION
this root image doesn't get updated anymore: https://hub.docker.com/r/centos/httpd/tags

we need to run a yum update on builds to replicate prod envs

```bash

❯ docker exec -it boars-head-rebuild-httpd-1 /bin/bash
[root@58ecbb5df475 /]# yum info httpd
Loaded plugins: fastestmirror, ovl
Determining fastest mirrors
 * base: packages.oit.ncsu.edu
 * extras: mirror.ette.biz
 * updates: mirror.hostduplex.com
base                                                                                                                                                                                                                                                                                                                                               | 3.6 kB  00:00:00
extras                                                                                                                                                                                                                                                                                                                                             | 2.9 kB  00:00:00
updates                                                                                                                                                                                                                                                                                                                                            | 2.9 kB  00:00:00
(1/4): base/7/x86_64/group_gz                                                                                                                                                                                                                                                                                                                      | 153 kB  00:00:00
(2/4): extras/7/x86_64/primary_db                                                                                                                                                                                                                                                                                                                  | 249 kB  00:00:00
(3/4): base/7/x86_64/primary_db                                                                                                                                                                                                                                                                                                                    | 6.1 MB  00:00:02
(4/4): updates/7/x86_64/primary_db                                                                                                                                                                                                                                                                                                                 |  19 MB  00:00:04
Installed Packages
Name        : httpd
Arch        : x86_64
Version     : 2.4.6
Release     : 88.el7.centos
Size        : 9.4 M
Repo        : installed
From repo   : base
Summary     : Apache HTTP Server
URL         : http://httpd.apache.org/
License     : ASL 2.0
Description : The Apache HTTP Server is a powerful, efficient, and extensible
            : web server.

Available Packages
Name        : httpd
Arch        : x86_64
Version     : 2.4.6
Release     : 98.el7.centos.6
Size        : 2.7 M
Repo        : updates/7/x86_64
Summary     : Apache HTTP Server
URL         : http://httpd.apache.org/
License     : ASL 2.0
Description : The Apache HTTP Server is a powerful, efficient, and extensible
            : web server.
```